### PR TITLE
Support sending precalculated Contont-MD5 header

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -467,6 +467,7 @@ var supportedHeaders = map[string]bool{
 	"content-encoding":                    true,
 	"content-disposition":                 true,
 	"content-language":                    true,
+	"content-md5":                         true,
 	"x-amz-website-redirect-location":     true,
 	"x-amz-object-lock-mode":              true,
 	"x-amz-metadata-directive":            true,


### PR DESCRIPTION
We already have the MD5 of the content and want to send along the Content-MD5 header without minio-go having to recalculate the hash. With this PR we can set `SendContentMd5: false` and send our hash as `UserMetadata`.